### PR TITLE
perf: optimize lodash.isEqual import

### DIFF
--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -5,7 +5,7 @@ import React, {
   useImperativeHandle,
   useCallback,
 } from "react";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import InfinitePager, {
   InfinitePagerImperativeApi,
   PageInterpolatorParams,


### PR DESCRIPTION
# Why

Metro bundler is importing the entirety of `lodash` because it does not support tree-shaking.